### PR TITLE
Release v1.0.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3243,7 +3243,7 @@ dependencies = [
 
 [[package]]
 name = "taskbook-client"
-version = "1.0.5"
+version = "1.0.6"
 dependencies = [
  "arboard",
  "base64",
@@ -3266,7 +3266,7 @@ dependencies = [
 
 [[package]]
 name = "taskbook-common"
-version = "1.0.5"
+version = "1.0.6"
 dependencies = [
  "aes-gcm",
  "chrono",
@@ -3278,7 +3278,7 @@ dependencies = [
 
 [[package]]
 name = "taskbook-server"
-version = "1.0.5"
+version = "1.0.6"
 dependencies = [
  "argon2",
  "axum",

--- a/crates/taskbook-client/Cargo.toml
+++ b/crates/taskbook-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "taskbook-client"
-version = "1.0.5"
+version = "1.0.6"
 edition = "2021"
 rust-version = "1.75"
 description = "Tasks, boards & notes for the command-line habitat"

--- a/crates/taskbook-common/Cargo.toml
+++ b/crates/taskbook-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "taskbook-common"
-version = "1.0.5"
+version = "1.0.6"
 edition = "2021"
 rust-version = "1.75"
 description = "Shared types for taskbook-rs"

--- a/crates/taskbook-server/Cargo.toml
+++ b/crates/taskbook-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "taskbook-server"
-version = "1.0.5"
+version = "1.0.6"
 edition = "2021"
 rust-version = "1.75"
 description = "Server for taskbook-rs sync"

--- a/overlay.nix
+++ b/overlay.nix
@@ -1,6 +1,6 @@
 final: prev:
 let
-  version = "1.0.5";
+  version = "1.0.6";
 
   assets = {
     x86_64-linux = {

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -5,36 +5,40 @@ REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 
 usage() {
   cat <<'EOF'
-Usage: scripts/release.sh [--dry-run] <version> [remote]
+Usage: scripts/release.sh [options] <version> [remote]
+       scripts/release.sh --tag <version> [remote]
 
-Bumps all version strings, creates a release branch, and opens a pull
-request. After the PR is merged, tag the release with:
+Creates a release pull request, or tags a merged release.
 
-  git tag v<version> && git push origin v<version>
+Commands:
+  (default)     Create a release branch, bump versions, and open a PR.
+  --tag         After the PR is merged, tag the release on master and push
+                the tag to trigger the GitHub Actions release workflow.
 
 Options:
-  --dry-run   Update files and create commit locally but do NOT push or
-              create a pull request.
+  --dry-run     Perform changes locally but do NOT push or create a PR/tag.
 
 Arguments:
-  version     Semver version without 'v' prefix (e.g. 1.0.4)
-  remote      Git remote to push to (default: origin)
+  version       Semver version without 'v' prefix (e.g. 1.0.4)
+  remote        Git remote to push to (default: origin)
 
 Examples:
-  scripts/release.sh 1.0.4
-  scripts/release.sh --dry-run 1.0.4
-  scripts/release.sh 1.0.4 upstream
+  scripts/release.sh 1.0.6              # Create release PR
+  scripts/release.sh --dry-run 1.0.6    # Preview locally
+  scripts/release.sh --tag 1.0.6        # Tag after PR is merged
 EOF
 }
 
 # --------------- parse flags ---------------
 DRY_RUN=false
+TAG_MODE=false
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --dry-run) DRY_RUN=true; shift ;;
+    --tag)     TAG_MODE=true; shift ;;
     -h|--help) usage; exit 0 ;;
-    -*) echo "Unknown option: $1" >&2; usage; exit 1 ;;
-    *) break ;;
+    -*)        echo "Unknown option: $1" >&2; usage; exit 1 ;;
+    *)         break ;;
   esac
 done
 
@@ -46,12 +50,64 @@ fi
 VERSION="$1"
 REMOTE="${2:-origin}"
 TAG="v${VERSION}"
+BRANCH="release/${TAG}"
 
 # --------------- validate version ---------------
 if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
   echo "Error: version must be semver (e.g. 1.0.4), got '${VERSION}'" >&2
   exit 1
 fi
+
+# ===============================================================
+#  --tag mode: tag a merged release on master
+# ===============================================================
+if [[ "$TAG_MODE" == true ]]; then
+  if git -C "$REPO_ROOT" rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
+    echo "Error: tag ${TAG} already exists." >&2
+    exit 1
+  fi
+
+  echo "Switching to master and pulling latest changes ..."
+  git -C "$REPO_ROOT" checkout master
+  git -C "$REPO_ROOT" pull "${REMOTE}" master
+
+  # Sanity check: the version bump should be present on master
+  if ! grep -q "^version = \"${VERSION}\"" "$REPO_ROOT/crates/taskbook-client/Cargo.toml"; then
+    echo "Error: version ${VERSION} not found in crates/taskbook-client/Cargo.toml." >&2
+    echo "Has the release PR been merged?" >&2
+    exit 1
+  fi
+
+  git -C "$REPO_ROOT" tag "${TAG}"
+  echo "Created tag ${TAG}."
+
+  if [[ "$DRY_RUN" == true ]]; then
+    echo ""
+    echo "Dry-run mode: skipping push."
+    echo "To finish: git push ${REMOTE} ${TAG}"
+  else
+    git -C "$REPO_ROOT" push "${REMOTE}" "${TAG}"
+    echo "Pushed tag ${TAG} to ${REMOTE}. Release workflow should start shortly."
+  fi
+
+  # Clean up the release branch if it still exists
+  if git -C "$REPO_ROOT" rev-parse -q --verify "refs/heads/${BRANCH}" >/dev/null; then
+    git -C "$REPO_ROOT" branch -d "${BRANCH}"
+    echo "Deleted local branch ${BRANCH}."
+  fi
+  if git -C "$REPO_ROOT" ls-remote --exit-code --heads "${REMOTE}" "${BRANCH}" >/dev/null 2>&1; then
+    if [[ "$DRY_RUN" == false ]]; then
+      git -C "$REPO_ROOT" push "${REMOTE}" --delete "${BRANCH}"
+      echo "Deleted remote branch ${BRANCH}."
+    fi
+  fi
+
+  exit 0
+fi
+
+# ===============================================================
+#  Default mode: create release PR
+# ===============================================================
 
 # --------------- check preconditions ---------------
 if [[ -n "$(git -C "$REPO_ROOT" status --porcelain)" ]]; then
@@ -68,8 +124,6 @@ if ! command -v gh &>/dev/null; then
   echo "Error: 'gh' CLI is required to create pull requests." >&2
   exit 1
 fi
-
-BRANCH="release/${TAG}"
 
 if git -C "$REPO_ROOT" rev-parse -q --verify "refs/heads/${BRANCH}" >/dev/null; then
   echo "Error: branch ${BRANCH} already exists." >&2
@@ -123,8 +177,9 @@ echo "Created commit for ${TAG}."
 if [[ "$DRY_RUN" == true ]]; then
   echo ""
   echo "Dry-run mode: skipping push and PR creation."
-  echo "To finish the release, run:"
-  echo "  git push ${REMOTE} ${BRANCH} && gh pr create --title 'Release ${TAG}' --body 'Bump version to ${VERSION}.'"
+  echo "To finish the release:"
+  echo "  git push -u ${REMOTE} ${BRANCH}"
+  echo "  gh pr create --title 'Release ${TAG}' --body 'Bump version to ${VERSION}.'"
 else
   git -C "$REPO_ROOT" push -u "${REMOTE}" "${BRANCH}"
   PR_URL=$(gh pr create \
@@ -132,17 +187,16 @@ else
     --body "$(cat <<EOF
 Bump version to ${VERSION}.
 
-After merging, tag the release:
+After merging, finish the release:
 \`\`\`
-git pull && git tag ${TAG} && git push ${REMOTE} ${TAG}
+scripts/release.sh --tag ${VERSION}
 \`\`\`
 EOF
 )" \
-    --repo "$(gh repo view --json nameWithOwner -q .nameWithOwner)" \
   )
   echo ""
   echo "Pull request created: ${PR_URL}"
   echo ""
-  echo "After the PR is merged, tag the release:"
-  echo "  git checkout master && git pull && git tag ${TAG} && git push ${REMOTE} ${TAG}"
+  echo "After the PR is merged, run:"
+  echo "  scripts/release.sh --tag ${VERSION}"
 fi


### PR DESCRIPTION
## Summary
- Update release script to use pull request workflow instead of direct pushes
- Add `--tag` mode for post-merge tagging
- Bump version to 1.0.6

## After merging
```
scripts/release.sh --tag 1.0.6
```