### PR TITLE
Only run CI workflow on version tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,8 @@ name: CI
 
 on:
   push:
-    branches: [master]
-  pull_request:
-    branches: [master]
+    tags:
+      - 'v*'
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
## Summary
- Changed CI workflow trigger from push/PR on master to only run on `v*` tags
- Release workflow already triggered on tags only — no changes needed

## Test plan
- [ ] Verify CI no longer triggers on pushes to master or PRs
- [ ] Verify CI triggers when a `v*` tag is pushed

🤖 Generated with [Claude Code](https://claude.com/claude-code)