### PR TITLE
Update release script to auto-update overlay.nix hashes

### DIFF
--- a/overlay.nix
+++ b/overlay.nix
@@ -17,7 +17,7 @@ let
     };
     aarch64-darwin = {
       url = "https://github.com/taskbook-sh/taskbook/releases/download/v${version}/tb-macos-aarch64.tar.gz";
-      hash = "sha256-zuCn+JoEwa3SvZxEECJoZsm+BlqaGkge8wn9Ru9Fw7w=";
+      hash = "sha256-BM7Q5f7pDZbKWYKfCtEGhWndPjDtOkd9GrMKXjtOujc=";
     };
   };
 


### PR DESCRIPTION
## Summary
- Release script `--tag` mode now waits for the release workflow to complete, downloads tarballs, computes SRI hashes, and updates `overlay.nix` on master automatically
- Fix aarch64-darwin hash for v1.0.7

## Test plan
- [ ] Run `scripts/release.sh --dry-run --tag <version>` to verify the script still works in dry-run mode
- [ ] On next release, verify hashes in `overlay.nix` are updated automatically after `--tag`

🤖 Generated with [Claude Code](https://claude.com/claude-code)