### PR TITLE
Persist hide-completed setting across TUI sessions

### DIFF
--- a/crates/taskbook-client/src/tui/app.rs
+++ b/crates/taskbook-client/src/tui/app.rs
@@ -142,7 +142,10 @@ impl App {
             items: HashMap::new(),
             popup: None,
             status_message: None,
-            filter: FilterState::default(),
+            filter: FilterState {
+                hide_completed: !config.display_complete_tasks,
+                ..Default::default()
+            },
             running: true,
             theme,
             config,
@@ -278,6 +281,8 @@ impl App {
     /// Toggle hide completed tasks
     pub fn toggle_hide_completed(&mut self) {
         self.filter.hide_completed = !self.filter.hide_completed;
+        self.config.display_complete_tasks = !self.filter.hide_completed;
+        let _ = self.config.save();
         self.update_display_order();
         // Clamp selection
         if !self.display_order.is_empty() && self.selected_index >= self.display_order.len() {


### PR DESCRIPTION
## Summary
- Wire up the existing `display_complete_tasks` config field so the TUI respects it on startup and saves it when toggled with `h`
- `FilterState.hide_completed` is initialized from `!config.display_complete_tasks`
- Toggling writes back to `~/.taskbook.json` (best-effort, won't break TUI on write failure)

## Test plan
- [ ] Launch TUI, press `h` to hide completed, exit, relaunch — completed tasks should still be hidden
- [ ] Press `h` again to show, exit, relaunch — completed tasks should be visible
- [ ] Check `~/.taskbook.json` shows `"displayCompleteTasks": false` / `true` after toggling

🤖 Generated with [Claude Code](https://claude.com/claude-code)