### PR TITLE
Wire up TUI search filtering

### DIFF
--- a/crates/taskbook-client/src/tui/actions.rs
+++ b/crates/taskbook-client/src/tui/actions.rs
@@ -18,8 +18,12 @@ pub fn handle_key_event(app: &mut App, key: KeyEvent) -> Result<()> {
         // Quit
         KeyCode::Char('q') => app.quit(),
         KeyCode::Esc => {
-            // If board filter is active, clear it; otherwise quit
-            if app.filter.board_filter.is_some() {
+            if app.filter.search_term.is_some() {
+                app.filter.search_term = None;
+                app.update_display_order();
+                app.selected_index = 0;
+                app.set_status("Search cleared".to_string(), StatusKind::Info);
+            } else if app.filter.board_filter.is_some() {
                 app.clear_board_filter();
                 app.set_status("Filter cleared".to_string(), StatusKind::Info);
             } else {
@@ -241,7 +245,15 @@ fn handle_popup_key(app: &mut App, key: KeyEvent, popup: PopupState) -> Result<(
             }
             InputResult::Submit => {
                 if !input.trim().is_empty() {
+                    let term = input.clone();
                     app.filter.search_term = Some(input);
+                    app.update_display_order();
+                    app.selected_index = 0;
+                    let count = app.display_order.len();
+                    app.set_status(
+                        format!("Search: \"{}\" ({} matches)", term, count),
+                        StatusKind::Info,
+                    );
                 }
                 app.popup = None;
             }

--- a/crates/taskbook-client/src/tui/app.rs
+++ b/crates/taskbook-client/src/tui/app.rs
@@ -213,12 +213,18 @@ impl App {
     }
 
     /// Check if an item should be shown based on current filters
-    fn should_show_item(&self, item: &StorageItem) -> bool {
+    pub fn should_show_item(&self, item: &StorageItem) -> bool {
         if self.filter.hide_completed {
             if let Some(task) = item.as_task() {
                 if task.is_complete {
                     return false;
                 }
+            }
+        }
+        if let Some(ref term) = self.filter.search_term {
+            let term_lower = term.to_lowercase();
+            if !item.description().to_lowercase().contains(&term_lower) {
+                return false;
             }
         }
         true

--- a/crates/taskbook-client/src/tui/widgets/board_view.rs
+++ b/crates/taskbook-client/src/tui/widgets/board_view.rs
@@ -46,17 +46,10 @@ pub fn render_board_view(frame: &mut Frame, app: &App, area: Rect) {
             .filter(|t| t.is_complete)
             .count();
 
-        // Filter items for display (respecting hide_completed)
+        // Filter items for display (respecting all active filters)
         let visible_items: Vec<&StorageItem> = board_items
             .into_iter()
-            .filter(|item| {
-                if app.filter.hide_completed {
-                    if let Some(task) = item.as_task() {
-                        return !task.is_complete;
-                    }
-                }
-                true
-            })
+            .filter(|item| app.should_show_item(item))
             .collect();
 
         // Skip board if all visible items are hidden

--- a/crates/taskbook-client/src/tui/widgets/help_popup.rs
+++ b/crates/taskbook-client/src/tui/widgets/help_popup.rs
@@ -105,8 +105,16 @@ pub fn render_help_popup(frame: &mut Frame, app: &App) {
             Span::styled("Archive view", desc_style),
         ]),
         Line::from(vec![
+            Span::styled("    /       ", key_style),
+            Span::styled("Search items", desc_style),
+        ]),
+        Line::from(vec![
             Span::styled("    h       ", key_style),
             Span::styled("Toggle hide completed", desc_style),
+        ]),
+        Line::from(vec![
+            Span::styled("    Esc     ", key_style),
+            Span::styled("Clear search/filter / Quit", desc_style),
         ]),
         Line::from(vec![
             Span::styled("    Enter   ", key_style),

--- a/crates/taskbook-client/src/tui/widgets/status_bar.rs
+++ b/crates/taskbook-client/src/tui/widgets/status_bar.rs
@@ -14,7 +14,7 @@ pub fn render_status_bar(frame: &mut Frame, app: &App, area: Rect) {
         .constraints([Constraint::Length(1), Constraint::Length(1)])
         .split(area);
 
-    // Stats line or status message
+    // Stats line, status message, or search indicator
     if let Some(ref msg) = app.status_message {
         let style = match msg.kind {
             StatusKind::Success => app.theme.success,
@@ -23,6 +23,17 @@ pub fn render_status_bar(frame: &mut Frame, app: &App, area: Rect) {
         };
         let line = Line::from(vec![Span::raw("  "), Span::styled(&msg.text, style)]);
         frame.render_widget(Paragraph::new(line), chunks[0]);
+    } else if let Some(ref term) = app.filter.search_term {
+        let search_line = Line::from(vec![
+            Span::raw("  "),
+            Span::styled("Search: ", app.theme.info),
+            Span::styled(
+                format!("\"{}\"", term),
+                app.theme.info.add_modifier(Modifier::BOLD),
+            ),
+            Span::styled("  (Esc to clear)", app.theme.muted),
+        ]);
+        frame.render_widget(Paragraph::new(search_line), chunks[0]);
     } else if app.config.display_progress_overview {
         let stats = app.get_stats();
         let stats_line = Line::from(vec![

--- a/crates/taskbook-client/src/tui/widgets/timeline_view.rs
+++ b/crates/taskbook-client/src/tui/widgets/timeline_view.rs
@@ -48,17 +48,10 @@ pub fn render_timeline_view(frame: &mut Frame, app: &App, area: Rect) {
             .filter(|t| t.is_complete)
             .count();
 
-        // Filter items for display (respecting hide_completed)
+        // Filter items for display (respecting all active filters)
         let visible_items: Vec<&StorageItem> = date_items
             .iter()
-            .filter(|item| {
-                if app.filter.hide_completed {
-                    if let Some(task) = item.as_task() {
-                        return !task.is_complete;
-                    }
-                }
-                true
-            })
+            .filter(|item| app.should_show_item(item))
             .copied()
             .collect();
 


### PR DESCRIPTION
## Summary
- The search popup (`/`) accepted input but never applied it — now it actually filters items
- `should_show_item()` checks `search_term` with case-insensitive substring matching on descriptions
- `Esc` clears active search first, then board filter, then quits (layered)
- Status bar shows persistent search indicator (`Search: "term" (Esc to clear)`) when a search is active
- Board and timeline views now use the shared `should_show_item()` instead of duplicating filter logic inline

## Test plan
- [ ] Press `/`, type a search term, press Enter — only matching items should be shown
- [ ] Verify match count is displayed in status bar
- [ ] Status bar shows `Search: "term" (Esc to clear)` persistently while search is active
- [ ] Press `Esc` — search clears and all items reappear
- [ ] Search works in both board view (`1`) and timeline view (`2`)
- [ ] Search + hide completed (`h`) stack correctly (both filters applied)
- [ ] Help popup (`?`) shows `/` and `Esc` keybindings

🤖 Generated with [Claude Code](https://claude.com/claude-code)