### PR TITLE
Fix darwin CI runner and align artifact naming

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,10 +21,10 @@ jobs:
             os: ubuntu-latest
             name: tb-linux-aarch64
           - target: x86_64-apple-darwin
-            os: darwin-latest
+            os: macos-latest
             name: tb-darwin-x86_64
           - target: aarch64-apple-darwin
-            os: darwin-latest
+            os: macos-latest
             name: tb-darwin-aarch64
 
     runs-on: ${{ matrix.os }}

--- a/overlay.nix
+++ b/overlay.nix
@@ -12,11 +12,11 @@ let
       hash = "sha256-Qmnvhg21D9J67LORuk+x3CMxD4bghP4px5vDW34aakc=";
     };
     x86_64-darwin = {
-      url = "https://github.com/taskbook-sh/taskbook/releases/download/v${version}/tb-macos-x86_64.tar.gz";
+      url = "https://github.com/taskbook-sh/taskbook/releases/download/v${version}/tb-darwin-x86_64.tar.gz";
       hash = "sha256-QQrfzzC+N2e22eyKSQSuAsutJExd0U9rHneRv00TU0Q=";
     };
     aarch64-darwin = {
-      url = "https://github.com/taskbook-sh/taskbook/releases/download/v${version}/tb-macos-aarch64.tar.gz";
+      url = "https://github.com/taskbook-sh/taskbook/releases/download/v${version}/tb-darwin-aarch64.tar.gz";
       hash = "sha256-BM7Q5f7pDZbKWYKfCtEGhWndPjDtOkd9GrMKXjtOujc=";
     };
   };

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -135,8 +135,8 @@ if [[ "$TAG_MODE" == true ]]; then
     TARBALLS=(
       "tb-linux-x86_64.tar.gz"
       "tb-linux-aarch64.tar.gz"
-      "tb-macos-x86_64.tar.gz"
-      "tb-macos-aarch64.tar.gz"
+      "tb-darwin-x86_64.tar.gz"
+      "tb-darwin-aarch64.tar.gz"
     )
 
     for tarball in "${TARBALLS[@]}"; do


### PR DESCRIPTION
## Summary
- Use `macos-latest` instead of `darwin-latest` for GitHub Actions runners (darwin jobs were never picked up)
- Update `overlay.nix` URLs to match `tb-darwin-*` artifact names from release workflow
- Update `scripts/release.sh` tarball list to match `tb-darwin-*` naming

## After merge
Delete and re-tag v1.0.8 to trigger the release workflow:
```
git tag v1.0.8 && git push origin v1.0.8
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)