### PR TITLE
Fix TUI board sorting stability and note editor bugs

### DIFF
--- a/crates/taskbook-client/src/config.rs
+++ b/crates/taskbook-client/src/config.rs
@@ -159,6 +159,39 @@ impl ThemeConfig {
     }
 }
 
+/// Sort method for items within boards
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SortMethod {
+    /// Sort by item ID (creation order)
+    #[default]
+    Id,
+    /// Sort by priority (high first), then ID
+    Priority,
+    /// Sort by status (pending, in-progress, done), then ID
+    Status,
+}
+
+impl SortMethod {
+    /// Cycle to the next sort method
+    pub fn next(self) -> Self {
+        match self {
+            SortMethod::Id => SortMethod::Priority,
+            SortMethod::Priority => SortMethod::Status,
+            SortMethod::Status => SortMethod::Id,
+        }
+    }
+
+    /// Display name for the sort method
+    pub fn display_name(self) -> &'static str {
+        match self {
+            SortMethod::Id => "ID",
+            SortMethod::Priority => "Priority",
+            SortMethod::Status => "Status",
+        }
+    }
+}
+
 /// Sync configuration for remote server
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -201,6 +234,9 @@ pub struct Config {
 
     #[serde(default)]
     pub sync: SyncConfig,
+
+    #[serde(default)]
+    pub sort_method: SortMethod,
 }
 
 fn default_taskbook_directory() -> String {
@@ -219,6 +255,7 @@ impl Default for Config {
             display_progress_overview: true,
             theme: ThemeConfig::default(),
             sync: SyncConfig::default(),
+            sort_method: SortMethod::default(),
         }
     }
 }

--- a/crates/taskbook-client/src/taskbook.rs
+++ b/crates/taskbook-client/src/taskbook.rs
@@ -109,12 +109,21 @@ impl Taskbook {
     fn get_boards(&self, data: &HashMap<String, StorageItem>) -> Vec<String> {
         let mut boards = vec![DEFAULT_BOARD.to_string()];
 
-        for item in data.values() {
+        // Iterate items in ID order for deterministic board discovery
+        let mut items: Vec<_> = data.iter().collect();
+        items.sort_by_key(|(k, _)| k.parse::<u64>().unwrap_or(u64::MAX));
+
+        for (_, item) in &items {
             for b in item.boards() {
                 if !boards.iter().any(|existing| board::board_eq(existing, b)) {
                     boards.push(b.clone());
                 }
             }
+        }
+
+        // Sort non-default boards alphabetically (case-insensitive), keeping default first
+        if boards.len() > 1 {
+            boards[1..].sort_by_key(|a| a.to_lowercase());
         }
 
         boards

--- a/crates/taskbook-client/src/tui/actions.rs
+++ b/crates/taskbook-client/src/tui/actions.rs
@@ -191,6 +191,14 @@ pub fn handle_key_event(app: &mut App, key: KeyEvent) -> Result<()> {
                 cursor: 0,
             });
         }
+        // Cycle sort method
+        KeyCode::Char('S') if app.view == ViewMode::Board => {
+            app.cycle_sort_method();
+            app.set_status(
+                format!("Sort: {}", app.sort_method.display_name()),
+                StatusKind::Info,
+            );
+        }
         // Toggle hide completed
         KeyCode::Char('h') if app.view != ViewMode::Archive => {
             app.toggle_hide_completed();

--- a/crates/taskbook-client/src/tui/event.rs
+++ b/crates/taskbook-client/src/tui/event.rs
@@ -37,6 +37,13 @@ pub fn resume_event_handler() {
     EVENT_POLLING_PAUSED.store(false, Ordering::SeqCst);
 }
 
+/// Drain any buffered input events (e.g. stale keystrokes from external editor)
+pub fn drain_input_buffer() {
+    while event::poll(Duration::from_millis(0)).unwrap_or(false) {
+        let _ = event::read();
+    }
+}
+
 /// Event handler with background thread
 pub struct EventHandler {
     receiver: mpsc::Receiver<Event>,

--- a/crates/taskbook-client/src/tui/mod.rs
+++ b/crates/taskbook-client/src/tui/mod.rs
@@ -75,6 +75,9 @@ impl TuiSuspendGuard {
         .map_err(|e| TaskbookError::Tui(e.to_string()))?;
         stdout.flush().ok();
 
+        // Drain any stale keyboard events buffered while the editor was running
+        event::drain_input_buffer();
+
         // Resume the event handler thread
         event::resume_event_handler();
 

--- a/crates/taskbook-client/src/tui/widgets/board_view.rs
+++ b/crates/taskbook-client/src/tui/widgets/board_view.rs
@@ -5,7 +5,7 @@ use ratatui::{
     Frame,
 };
 
-use crate::tui::app::App;
+use crate::tui::app::{sort_items_by, App};
 use taskbook_common::board;
 use taskbook_common::StorageItem;
 
@@ -74,9 +74,9 @@ pub fn render_board_view(frame: &mut Frame, app: &App, area: Rect) {
         ]));
         item_line_map.push(None);
 
-        // Sort items by ID
+        // Sort items using configured method
         let mut sorted_items = visible_items;
-        sorted_items.sort_by_key(|item| item.id());
+        sort_items_by(&mut sorted_items, app.sort_method);
 
         for item in sorted_items {
             let is_selected = app.selected_id() == Some(item.id());

--- a/crates/taskbook-client/src/tui/widgets/help_popup.rs
+++ b/crates/taskbook-client/src/tui/widgets/help_popup.rs
@@ -9,7 +9,7 @@ use crate::tui::app::App;
 use crate::tui::ui::centered_rect;
 
 pub fn render_help_popup(frame: &mut Frame, app: &App) {
-    let area = centered_rect(50, 32, frame.area());
+    let area = centered_rect(50, 33, frame.area());
 
     let block = Block::default()
         .title(" Keybindings ")
@@ -103,6 +103,10 @@ pub fn render_help_popup(frame: &mut Frame, app: &App) {
         Line::from(vec![
             Span::styled("    3       ", key_style),
             Span::styled("Archive view", desc_style),
+        ]),
+        Line::from(vec![
+            Span::styled("    S       ", key_style),
+            Span::styled("Cycle sort method", desc_style),
         ]),
         Line::from(vec![
             Span::styled("    /       ", key_style),


### PR DESCRIPTION
## Summary
- **Deterministic board sorting**: `get_boards()` now iterates items in ID order and sorts non-default boards alphabetically (case-insensitive), keeping "My Board" first. Board order no longer shuffles on every refresh.
- **Configurable sort method**: Added `SortMethod` enum (ID/Priority/Status) to config. Press `S` in Board view to cycle sort methods. Persisted across sessions.
- **Note editor `#` corruption fix**: Changed editor comment marker from `#` to `//` so note titles starting with `#` (e.g. markdown headings) are preserved.
- **Stale input buffer drain**: Added `drain_input_buffer()` called on TUI resume after external editor closes, preventing buffered keystrokes from requiring extra Escape presses.

## Test plan
- [x] `cargo clippy` — zero warnings
- [x] `cargo test` — all 35 tests pass (including new `test_parse_hash_in_title_preserved`)
- [ ] Manual: launch TUI, create items in multiple boards, verify board order is stable across refreshes
- [ ] Manual: press `S` to cycle sort methods, verify items reorder correctly
- [ ] Manual: create a note with `#` in the title, edit it, verify title preserved
- [ ] Manual: after closing external editor, verify immediate return to main view

🤖 Generated with [Claude Code](https://claude.com/claude-code)