### PR TITLE
Support quoted board names with spaces in TUI

### DIFF
--- a/crates/taskbook-client/src/tui/autocomplete.rs
+++ b/crates/taskbook-client/src/tui/autocomplete.rs
@@ -120,6 +120,7 @@ fn suggest_boards(app: &mut App, partial: &str) {
             || b.to_lowercase().starts_with(&partial_lower)
         {
             // Build the completion: replace the @partial with @board
+            // Quote board names that contain spaces
             let input_chars: Vec<char> = app.command_line.input.chars().collect();
             let cursor = app.command_line.cursor.min(input_chars.len());
 
@@ -127,7 +128,12 @@ fn suggest_boards(app: &mut App, partial: &str) {
             if let Some(at_pos) = input_chars[..cursor].iter().rposition(|c| *c == '@') {
                 let before_at: String = input_chars[..at_pos].iter().collect();
                 let after_cursor: String = input_chars[cursor..].iter().collect();
-                let completion = format!("{}@{} {}", before_at, b, after_cursor);
+                let board_ref = if b.contains(' ') {
+                    format!("@\"{}\"", b)
+                } else {
+                    format!("@{}", b)
+                };
+                let completion = format!("{}{} {}", before_at, board_ref, after_cursor);
 
                 app.command_line.suggestions.push(Suggestion {
                     display: format!("@{}", display),

--- a/crates/taskbook-client/src/tui/widgets/help_popup.rs
+++ b/crates/taskbook-client/src/tui/widgets/help_popup.rs
@@ -102,6 +102,10 @@ pub fn render_help_popup(frame: &mut Frame, app: &App) {
             Span::styled("@board Description p:2", desc_style),
         ]),
         Line::from(vec![
+            Span::styled("             ", cmd_style),
+            Span::styled("@\"board name\" for spaces", desc_style),
+        ]),
+        Line::from(vec![
             Span::styled("    /note    ", cmd_style),
             Span::styled("@board Title", desc_style),
         ]),


### PR DESCRIPTION
## Summary
- Add `@"board name"` syntax to TUI command parser so board names with spaces (e.g., `MiST: IT-Leder`) are preserved correctly in `/task`, `/note`, `/move`, and `/rename-board` commands
- Autocomplete now automatically quotes board names containing spaces
- Updated help popup to show the quoting syntax

## Test plan
- [x] All 49 existing + new tests pass (`cargo test`)
- [x] No clippy warnings (`cargo clippy`)
- [ ] Manually test `/task @"Board Name" description` in TUI
- [ ] Verify autocomplete inserts `@"Board Name"` for boards with spaces
- [ ] Verify unquoted `@board` still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)