### PR TITLE
Esc no longer quits; use q or /quit instead

### DIFF
--- a/crates/taskbook-client/src/tui/actions.rs
+++ b/crates/taskbook-client/src/tui/actions.rs
@@ -261,6 +261,9 @@ fn execute_command(app: &mut App, cmd: ParsedCommand) -> Result<()> {
         ParsedCommand::Help => {
             app.popup = Some(PopupState::Help);
         }
+        ParsedCommand::Quit => {
+            app.quit();
+        }
     }
     Ok(())
 }
@@ -284,8 +287,6 @@ fn handle_shortcut_key(app: &mut App, key: KeyEvent) -> Result<()> {
             } else if app.filter.board_filter.is_some() {
                 app.clear_board_filter();
                 app.set_status("Filter cleared".to_string(), StatusKind::Info);
-            } else {
-                app.quit();
             }
         }
 

--- a/crates/taskbook-client/src/tui/autocomplete.rs
+++ b/crates/taskbook-client/src/tui/autocomplete.rs
@@ -22,6 +22,7 @@ const COMMANDS: &[(&str, &str)] = &[
     ("sort", "Cycle sort method"),
     ("hide-done", "Toggle hide completed"),
     ("help", "Show help"),
+    ("quit", "Quit application"),
 ];
 
 /// Commands that accept item ID references (@<id>)

--- a/crates/taskbook-client/src/tui/command_parser.rs
+++ b/crates/taskbook-client/src/tui/command_parser.rs
@@ -49,6 +49,7 @@ pub enum ParsedCommand {
     Sort,
     HideDone,
     Help,
+    Quit,
 }
 
 #[derive(Debug, Clone)]
@@ -104,6 +105,7 @@ pub fn parse_command(input: &str) -> Result<ParsedCommand, ParseError> {
         "sort" => Ok(ParsedCommand::Sort),
         "hide-done" => Ok(ParsedCommand::HideDone),
         "help" => Ok(ParsedCommand::Help),
+        "quit" | "q" => Ok(ParsedCommand::Quit),
         _ => Err(ParseError {
             message: format!("Unknown command: /{}", cmd),
         }),


### PR DESCRIPTION
## Summary
- **Esc key** no longer quits the application — it only clears active search/board filters
- **`q` shortcut** remains the keyboard shortcut to quit
- **`/quit`** (and `/q`) added as a new slash command with autocomplete support

## Test plan
- [ ] Press Esc with no active filters — app should not quit
- [ ] Press Esc with active search — search clears
- [ ] Press Esc with board filter — filter clears
- [ ] Press `q` in normal mode — app quits
- [ ] Type `/quit` or `/q` in command line — app quits
- [ ] `/quit` appears in autocomplete suggestions

🤖 Generated with [Claude Code](https://claude.com/claude-code)