### PR TITLE
Remember last-used TUI view between sessions

### DIFF
--- a/crates/taskbook-client/src/tui/mod.rs
+++ b/crates/taskbook-client/src/tui/mod.rs
@@ -11,7 +11,7 @@ pub mod widgets;
 use crate::config::Config;
 use crate::credentials::Credentials;
 use crate::error::{Result, TaskbookError};
-pub use app::App;
+pub use app::{App, ViewMode};
 
 use std::io::{self, Write};
 use std::path::Path;


### PR DESCRIPTION
## Summary
- Persist the active TUI view mode (Board, Timeline, Archive, Journal) to `~/.taskbook.json` as `defaultView`
- Reopening `tb` restores the last-used view instead of always starting on Board
- Follows the existing `SortMethod` persistence pattern exactly

## Test plan
- [x] `cargo test --workspace` — all 58 tests pass (2 new config tests added)
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [ ] Manual: run `tb`, switch to journal view (press 3), quit (q), reopen `tb` — should start in journal view
- [ ] Verify backward compatibility: existing `~/.taskbook.json` without `defaultView` starts on Board

🤖 Generated with [Claude Code](https://claude.com/claude-code)