### PR TITLE
Fix OTLP NoHttpClient panic

### DIFF
--- a/crates/taskbook-server/Cargo.toml
+++ b/crates/taskbook-server/Cargo.toml
@@ -24,7 +24,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "registry", "fmt"] }
 opentelemetry = { version = "0.28", default-features = false, features = ["trace", "metrics", "logs"] }
 opentelemetry_sdk = { version = "0.28", features = ["rt-tokio", "metrics", "logs"] }
-opentelemetry-otlp = { version = "0.28", features = ["trace", "metrics", "logs", "http-proto", "reqwest-client", "reqwest-rustls"] }
+opentelemetry-otlp = { version = "0.28", features = ["trace", "metrics", "logs", "http-proto", "reqwest-blocking-client", "reqwest-rustls"] }
 opentelemetry-semantic-conventions = "0.28"
 tracing-opentelemetry = { version = "0.29", features = ["metrics"] }
 opentelemetry-appender-tracing = "0.28"


### PR DESCRIPTION
## Summary

- Switch `opentelemetry-otlp` from `reqwest-client` back to `reqwest-blocking-client` (which auto-registers as the HTTP client) while keeping `reqwest-rustls` for TLS
- The `reqwest-client` (async) feature does not auto-register, causing `NoHttpClient` panic at startup

## Test plan

- [x] `cargo clippy` — zero warnings
- [x] `cargo test` — all tests pass
- [x] Tested locally against Grafana Cloud OTLP HTTPS endpoint — logs export successfully, TLS handshake works, connection pooling active

🤖 Generated with [Claude Code](https://claude.com/claude-code)