### PR TITLE
Only run CI on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches: [master]
   pull_request:
 
 env:


### PR DESCRIPTION
## Summary

- Remove `push: branches: [master]` trigger from CI workflow
- Keep only `pull_request` trigger
- Fixes double workflow execution when using `scripts/release.sh` (which pushes to master + tag simultaneously, triggering both CI and Release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)