### PR TITLE
Add Docker image info to releases, README, and docs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -237,8 +237,25 @@ jobs:
           path: artifacts
           pattern: tb-*
 
+      - name: Get version
+        id: version
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
       - name: Create release
         uses: softprops/action-gh-release@v2
         with:
           files: artifacts/**/*.tar.gz
           generate_release_notes: true
+          append_body: true
+          body: |
+            ## Docker Images
+
+            ```bash
+            # Server
+            docker pull ghcr.io/taskbook-sh/taskbook-server:${{ steps.version.outputs.version }}
+
+            # Client
+            docker pull ghcr.io/taskbook-sh/taskbook-client:${{ steps.version.outputs.version }}
+            ```
+
+            Both images support `linux/amd64` and `linux/arm64`. See the [Server Setup](https://github.com/taskbook-sh/taskbook/blob/master/docs/server.md) docs for usage.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,16 @@ Download the latest binary from [releases](https://github.com/taskbook-sh/taskbo
 cargo install --path crates/taskbook-client
 ```
 
+### Docker (server)
+
+Pre-built images are published to GHCR on every release:
+
+```bash
+docker pull ghcr.io/taskbook-sh/taskbook-server:latest
+```
+
+Or use Docker Compose for a full setup with PostgreSQL — see [Server Setup](docs/server.md).
+
 ### Nix Flake
 
 ```nix

--- a/crates/taskbook-server/src/telemetry.rs
+++ b/crates/taskbook-server/src/telemetry.rs
@@ -17,7 +17,9 @@ pub fn init_telemetry() -> PrometheusHandle {
     tracing_subscriber::fmt().with_env_filter(env_filter).init();
 
     PrometheusBuilder::new()
-        .set_buckets(&[0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0])
+        .set_buckets(&[
+            0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0,
+        ])
         .expect("failed to set histogram buckets")
         .install_recorder()
         .expect("failed to install Prometheus recorder")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,9 +16,11 @@ services:
       retries: 5
 
   server:
-    build:
-      context: .
-      dockerfile: Dockerfile.server
+    image: ghcr.io/taskbook-sh/taskbook-server:latest
+    # To build from source instead, comment the image line above and uncomment:
+    # build:
+    #   context: .
+    #   dockerfile: Dockerfile.server
     environment:
       TB_HOST: "0.0.0.0"
       TB_PORT: "8080"
@@ -36,9 +38,11 @@ services:
         condition: service_healthy
 
   client:
-    build:
-      context: .
-      dockerfile: Dockerfile.client
+    image: ghcr.io/taskbook-sh/taskbook-client:latest
+    # To build from source instead, comment the image line above and uncomment:
+    # build:
+    #   context: .
+    #   dockerfile: Dockerfile.client
     volumes:
       - client_data:/root/.taskbook
     depends_on:

--- a/docs/server.md
+++ b/docs/server.md
@@ -9,13 +9,9 @@ The taskbook server (`tb-server`) provides sync capabilities for accessing your 
 
 ## Quick Start with Docker Compose
 
-The easiest way to run the server is with Docker Compose:
+The easiest way to run the server is with Docker Compose. Download the [`docker-compose.yml`](https://github.com/taskbook-sh/taskbook/blob/master/docker-compose.yml) and run:
 
 ```bash
-# Clone the repository
-git clone https://github.com/taskbook-sh/taskbook.git
-cd taskbook
-
 # Start the server and database
 docker compose up -d
 
@@ -73,11 +69,13 @@ The server automatically runs database migrations on startup.
 
 ## Docker
 
-### Build the Image
+Pre-built multi-arch (`linux/amd64`, `linux/arm64`) images are published to GHCR on every release:
 
 ```bash
-docker build -f Dockerfile.server -t taskbook-server .
+docker pull ghcr.io/taskbook-sh/taskbook-server:latest
 ```
+
+Available tags: `latest`, `1.3.3`, `1.3`, `1` (semver).
 
 ### Run with Docker
 
@@ -89,7 +87,15 @@ docker run -d \
   -e TB_DB_NAME=taskbook \
   -e TB_DB_USER=postgres \
   -e TB_DB_PASSWORD=secret \
-  taskbook-server
+  ghcr.io/taskbook-sh/taskbook-server:latest
+```
+
+### Build from Source
+
+To build the image locally instead:
+
+```bash
+docker build -f Dockerfile.server -t taskbook-server .
 ```
 
 ## docker-compose.yml
@@ -111,9 +117,7 @@ services:
       retries: 5
 
   server:
-    build:
-      context: .
-      dockerfile: Dockerfile.server
+    image: ghcr.io/taskbook-sh/taskbook-server:latest
     environment:
       TB_HOST: "0.0.0.0"
       TB_PORT: "8080"


### PR DESCRIPTION
## Summary

- **Release workflow**: Appends a "Docker Images" section with `docker pull` commands to GitHub release notes, so GHCR images are discoverable from the release page
- **README**: Adds a Docker install section under Installation pointing to GHCR
- **docs/server.md**: Leads with pre-built GHCR images as the primary Docker path; build-from-source becomes a secondary option; Quick Start no longer requires cloning the repo
- **docker-compose.yml**: Uses `ghcr.io/taskbook-sh/taskbook-server` and `ghcr.io/taskbook-sh/taskbook-client` images by default instead of local builds

Closes #48

## Test plan

- [ ] Verify `docker compose up -d` works with the updated compose file pulling from GHCR
- [ ] Tag a test release and confirm the Docker Images section appears in the release notes
- [ ] Review README and server docs render correctly on GitHub

https://claude.ai/code/session_01JvfHX9qyvDRFqjU3ctHUs1