### PR TITLE
Fix double keystroke on Windows

### DIFF
--- a/crates/taskbook-client/src/tui/event.rs
+++ b/crates/taskbook-client/src/tui/event.rs
@@ -103,7 +103,9 @@ fn spawn_input_thread(sender: mpsc::Sender<Event>, tick_rate: u64) -> thread::Jo
                 continue;
             }
             match event::read() {
-                Ok(event::Event::Key(key)) => {
+                Ok(event::Event::Key(key))
+                    if key.kind == crossterm::event::KeyEventKind::Press =>
+                {
                     if sender.send(Event::Key(key)).is_err() {
                         break;
                     }


### PR DESCRIPTION
## Summary

- Filter key events to `KeyEventKind::Press` only in the TUI event handler, fixing double keystrokes on Windows where crossterm emits both press and release events

Fixes #46

## Test plan

- [ ] Verify on Windows that each keystroke registers once in command mode
- [ ] Verify no regression on Linux/macOS (they only emit press events, so behavior is unchanged)

https://claude.ai/code/session_01JvfHX9qyvDRFqjU3ctHUs1